### PR TITLE
Fix password endpoint returning wrong status

### DIFF
--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -231,9 +231,10 @@ app.post('/api/crypto', async (req, res) => {
 
 
 app.post('/api/set_password', async (req, res) => {
-    if(password === ''){
+    if (password === '') {
         password = req.body.password
         writeFileSync(passwordPath, password, 'utf-8')
+        return res.send({ status: 'ok' })
     }
     res.status(400).send("already set")
 })


### PR DESCRIPTION
## Summary
- return success when setting password via `/api/set_password`

## Testing
- `npm run check` *(fails: svelte-check not found)*
- `npx svelte-check --tsconfig ./tsconfig.json` *(fails to install)*

------
https://chatgpt.com/codex/tasks/task_e_6852706775c48327a046b0e5b4764520